### PR TITLE
Added control over SSL verification to support proxy usage

### DIFF
--- a/src/vinted_scraper/vintedScraper.py
+++ b/src/vinted_scraper/vintedScraper.py
@@ -11,36 +11,42 @@ class VintedScraper(VintedWrapper):
         agent: Optional[str] = None,
         session_cookie: Optional[str] = None,
         proxies: Optional[Dict] = None,
+        verify_ssl: bool = True,
     ):
         """
+        Vinted scraping client with data model support
+        
         :param baseurl: (required) Base Vinted site url to use in the requests
         :param agent: (optional) User agent to use on the requests
         :param session_cookie: (optional) Vinted session cookie
-        :param proxies: (optional) Dictionary mapping protocol or protocol and
-        hostname to the URL of the proxy. For more info see:
-        https://requests.readthedocs.io/en/latest/user/advanced/#proxies
+        :param proxies: (optional) Proxy configuration for requests
+        :param verify_ssl: (optional) Verify SSL certificates. Recommended for security.
         """
-        super().__init__(baseurl, agent, session_cookie, proxies)
+        super().__init__(
+            baseurl=baseurl,
+            agent=agent,
+            session_cookie=session_cookie,
+            proxies=proxies,
+            verify_ssl=verify_ssl,
+        )
 
     def search(self, params: Optional[Dict] = None) -> List[VintedItem]:  # type: ignore
         """
-        Search for items on Vinted.
-
-        :param params: an optional Dictionary with all the query parameters to append to the request.
-            Vinted supports a search without any parameters, but to perform a search,
-            you should add the `search_text` parameter.
-            Default value: None.
-        :return: A list of VintedItem instances representing search results.
+        Search for items on Vinted with model conversion
+        
+        :param params: Dictionary with search parameters
+        :return: List of VintedItem objects
         """
-        return [VintedItem(item) for item in super().search(params)["items"]]
+        raw_results = super().search(params)
+        return [VintedItem(item) for item in raw_results.get("items", [])]
 
     def item(self, item_id: str, params: Optional[Dict] = None) -> VintedItem:  # type: ignore
         """
-        Retrieve details of a specific item on Vinted.
-
-        :param item_id: The unique identifier of the item to retrieve.
-        :param params: an optional Dictionary with all the query parameters to append to the request.
-            Default value: None.
-        :return: A VintedItem instance representing the item's details.
+        Get detailed item information with model conversion
+        
+        :param item_id: Vinted item ID
+        :param params: Additional query parameters
+        :return: VintedItem object
         """
-        return VintedItem(super().item(item_id, params)["item"])
+        raw_data = super().item(item_id, params)
+        return VintedItem(raw_data.get("item", {}))

--- a/src/vinted_scraper/vintedWrapper.py
+++ b/src/vinted_scraper/vintedWrapper.py
@@ -15,129 +15,133 @@ class VintedWrapper:
         agent: Optional[str] = None,
         session_cookie: Optional[str] = None,
         proxies: Optional[Dict] = None,
+        verify_ssl: bool = True,
     ):
         """
-        :param baseurl: (required) Base Vinted site url to use in the requests
-        :param agent: (optional) User agent to use on the requests
-        :param session_cookie: (optional) Vinted session cookie
-        :param proxies: (optional) Dictionary mapping protocol or protocol and
-            hostname to the URL of the proxy. For more info see:
-        https://requests.readthedocs.io/en/latest/user/advanced/#proxies
+        Initialize the Vinted API wrapper
+        
+        :param baseurl: (required) Base Vinted site URL to use for requests
+        :param agent: (optional) Custom user agent string
+        :param session_cookie: (optional) Existing session cookie
+        :param proxies: (optional) Proxy configuration for requests
+        :param verify_ssl: (optional) Verify SSL certificates. Recommended to keep as True for security.
         """
-
         self.baseurl = baseurl[:-1] if baseurl.endswith("/") else baseurl
+        self.verify_ssl = verify_ssl
 
-        # Check if the URL is valid
+        # Validate base URL format
         if not re.match(
             re.compile(r"^(https?://)?(www\.)?[\w.-]+\.\w{2,}$"), self.baseurl
         ):
-            raise RuntimeError(f"{self.baseurl} is not a valid url, please check it!")
+            raise RuntimeError(f"Invalid base URL: {self.baseurl}")
 
-        self.user_agent = agent if agent is not None else get_random_user_agent()
+        self.user_agent = agent or get_random_user_agent()
         self.proxies = proxies
-        self.session_cookie = (
-            session_cookie if session_cookie is not None else self._fetch_cookie()
-        )
+        self.session_cookie = session_cookie or self._fetch_cookie()
 
     def _fetch_cookie(self, proxies: Optional[Dict] = None, retries: int = 3) -> str:
         """
-        Send an HTTP GET request to the self.base_url to fetch the session cookie with retries.
-
-        :param proxies: Optional proxy configuration for the HTTP request.
-            Use this if the proxy differs from the one set in the constructor.
-            This proxy will only be used to retrieve the session cookie.
-        :param retries: Number of retries for the HTTP request.
-        :return: The session cookie extracted from the HTTP response headers.
-        :raises RuntimeError: If the session cookie cannot be fetched or doesn't match the expected format.
+        Fetch session cookie from Vinted website
+        
+        :param proxies: Optional proxy configuration (overrides instance proxies)
+        :param retries: Number of retry attempts
+        :return: Session cookie string
         """
-        response = None
-        proxies = proxies if proxies is not None else self.proxies
-
-        for _ in range(retries):
-            response = requests.get(
-                self.baseurl,
-                headers=self._extended_headers(),
-                proxies=proxies,
-            )
-            if response.status_code == 200:
-                session_cookie = response.headers.get("Set-Cookie")
-                if session_cookie and "access_token_web=" in session_cookie:
-                    return session_cookie.split("access_token_web=")[1].split(";")[0]
-            else:
+        for attempt in range(retries):
+            try:
+                response = requests.get(
+                    self.baseurl,
+                    headers=self._extended_headers(),
+                    proxies=proxies or self.proxies,
+                    verify=self.verify_ssl,
+                )
+                
+                if response.status_code == 200:
+                    if cookie := response.headers.get("Set-Cookie", ""):
+                        if "access_token_web=" in cookie:
+                            return cookie.split("access_token_web=")[1].split(";")[0]
+                
                 # Exponential backoff before retrying
-                time.sleep(2**_)
+                time.sleep(2 ** attempt)
+                
+            except requests.exceptions.RequestException:
+                time.sleep(2 ** attempt)
 
         raise RuntimeError(
-            f"Cannot fetch session cookie from {self.baseurl}, because of "
-            f"status code: {response.status_code if response is not None else 'none'} different from 200."
+            f"Failed to fetch session cookie after {retries} attempts. "
+            f"Last status code: {getattr(response, 'status_code', 'No response')}"
         )
 
     def search(self, params: Optional[Dict] = None) -> Dict[str, Any]:
         """
-        Search for items on Vinted.
-
-        :param params: an optional Dictionary with all the query parameters to append to the request.
-            Vinted supports a search without any parameters, but to perform a search,
-            you should add the `search_text` parameter.
-            Default value: None.
-        :return: A Dict that contains the JSON response with the search results.
+        Search for items on Vinted
+        
+        :param params: Search parameters dictionary
+        :return: Search results as JSON dictionary
         """
         return self._curl("/catalog/items", params=params)
 
     def item(self, item_id: str, params: Optional[Dict] = None) -> Dict[str, Any]:
         """
-        Retrieve details of a specific item on Vinted.
-
-        :param item_id: The unique identifier of the item to retrieve.
-        :param params: an optional Dictionary with all the query parameters to append to the request.
-            Default value: None.
-        :return: A Dict that contains the JSON response with the item's details.
+        Get detailed information about a specific item
+        
+        :param item_id: Vinted item ID
+        :param params: Optional additional parameters
+        :return: Item details as JSON dictionary
         """
         return self._curl(f"/items/{item_id}", params=params)
 
     def _curl(self, endpoint: str, params: Optional[Dict] = None) -> Dict[str, Any]:
         """
-        Send an HTTP GET request to the specified endpoint.
-
-        :param endpoint: The endpoint to make the request to.
-        :param params: An optional dictionary with query parameters to include in the request.
-                       Default value: None.
-        :return: A dictionary containing the parsed JSON response from the endpoint.
-        :raises RuntimeError: If the HTTP response status code is not 200, indicating an error.
-
-        The method performs the following steps:
-        1. Constructs the HTTP headers, including the User-Agent and session Cookie.
-        2. Sends an HTTP GET request to the specified endpoint with the given parameters.
-        3. Checks if the HTTP response status code is 200 (indicating success).
-        4. If the response status code is 200, it parses the JSON content of the response
-            and returns it as a dictionary.
-        5. If the response status code is not 200, it raises a RuntimeError with an error message.
+        Execute API request with error handling and retry logic
+        
+        :param endpoint: API endpoint to call
+        :param params: Query parameters
+        :return: Response JSON as dictionary
         """
         headers = self._extended_headers(include_cookie=True)
-        response = requests.get(
-            f"{self.baseurl}/api/v2{endpoint}",
-            params=params,
-            headers=headers,
-            proxies=self.proxies,
-        )
+        max_retries = 3
+        retry_delay = 1  # seconds
 
-        if response.status_code == 200:
-            return json.loads(response.content)
-        elif response.status_code == 401:
-            # Fetch (maybe is expired?) the session cookie again and retry the API call
-            self.session_cookie = self._fetch_cookie()
-            return self._curl(endpoint, params)
-        else:
-            raise RuntimeError(
-                f"Cannot perform API call to endpoint {endpoint}, error code: {response.status_code}"
-            )
+        for attempt in range(max_retries):
+            try:
+                response = requests.get(
+                    f"{self.baseurl}/api/v2{endpoint}",
+                    params=params,
+                    headers=headers,
+                    proxies=self.proxies,
+                    verify=self.verify_ssl,
+                )
+
+                if response.status_code == 200:
+                    return json.loads(response.content)
+                elif response.status_code == 401:
+                    # Refresh expired session cookie and retry
+                    self.session_cookie = self._fetch_cookie()
+                    return self._curl(endpoint, params)
+                else:
+                    raise RuntimeError(
+                        f"API request failed to {endpoint} with status code {response.status_code}"
+                    )
+
+            except requests.exceptions.SSLError as e:
+                time.sleep(retry_delay)
+                if attempt == max_retries - 1:
+                    raise RuntimeError(f"SSL verification failed: {str(e)}")
+
+            except requests.exceptions.RequestException as e:
+                time.sleep(retry_delay)
+                if attempt == max_retries - 1:
+                    raise RuntimeError(f"Request failed after {max_retries} attempts: {str(e)}")
+
+        return {}
 
     def _extended_headers(self, include_cookie: bool = False) -> Dict[str, str]:
         """
-        Generate a more comprehensive set of HTTP headers to avoid bot detection by Cloudflare.
-
-        :param include_cookie: Whether to include the session cookie in the headers.
-        :return: A dictionary of headers.
+        Generate browser-like headers to avoid detection
+        
+        :param include_cookie: Whether to include session cookie
+        :return: Headers dictionary
         """
         headers = {
             "User-Agent": self.user_agent,
@@ -146,7 +150,7 @@ class VintedWrapper:
             "Accept-Language": "en-US,en;q=0.5",
             "Connection": "keep-alive",
             "Upgrade-Insecure-Requests": "1",
-            "DNT": "1",  # Do Not Track
+            "DNT": "1",
             "Sec-Fetch-Dest": "document",
             "Sec-Fetch-Mode": "navigate",
             "Sec-Fetch-Site": "none",


### PR DESCRIPTION
Proxies often intercept HTTPS traffic using self-signed certificates to inspect encrypted data (common in corporate networks). This breaks SSL verification because:

- The proxy's certificate doesn't match the target domain (e.g., vinted.fr).
- The proxy's Certificate Authority (CA) isn't trusted by Python's default trust store.

Python rejects the proxy's certificate, triggering `SSLCertVerificationError`.

The changes in this PR permit to disable SSL verification in the request calls. 
**Please, keep in mind that this is actually not safe and permits MITM attacks where malicious proxies/servers impersonate Vinted's domain**.

I suppose this shall be also highlighted in the doc.