### PR TITLE
refactor: don't force api prefix

### DIFF
--- a/src/vinted_scraper/_async_vinted_wrapper.py
+++ b/src/vinted_scraper/_async_vinted_wrapper.py
@@ -137,7 +137,7 @@ class AsyncVintedWrapper:
             you should add the `search_text` parameter. Default value: None.
         :return: A Dict that contains the JSON response with the search results.
         """
-        return await self._curl("/catalog/items", params=params)
+        return await self._curl("/api/v2/catalog/items", params=params)
 
     async def item(self, item_id: str, params: Optional[Dict] = None) -> Dict[str, Any]:
         """
@@ -148,7 +148,7 @@ class AsyncVintedWrapper:
             request. Default value: None.
         :return: A Dict that contains the JSON response with the item's details.
         """
-        return await self._curl(f"/items/{item_id}", params=params)
+        return await self._curl(f"/api/v2/items/{item_id}", params=params)
 
     async def _curl(
         self, endpoint: str, params: Optional[Dict] = None
@@ -171,7 +171,7 @@ class AsyncVintedWrapper:
         5. If the response status code is not 200, it raises a RuntimeError.
         """
         response = await self._client.get(
-            f"/api/v2{endpoint}",
+            endpoint,
             headers=get_curl_headers(
                 self._base_url, self._user_agent, self._session_cookie
             ),

--- a/src/vinted_scraper/_vinted_wrapper.py
+++ b/src/vinted_scraper/_vinted_wrapper.py
@@ -113,7 +113,7 @@ class VintedWrapper:
             Default value: None.
         :return: A Dict that contains the JSON response with the search results.
         """
-        return self._curl("/catalog/items", params=params)
+        return self._curl("/api/v2/catalog/items", params=params)
 
     def item(self, item_id: str, params: Optional[Dict] = None) -> Dict[str, Any]:
         """
@@ -124,7 +124,7 @@ class VintedWrapper:
             to the request. Default value: None.
         :return: A Dict that contains the JSON response with the item's details.
         """
-        return self._curl(f"/items/{item_id}/details", params=params)
+        return self._curl(f"/api/v2/items/{item_id}/details", params=params)
 
     def _curl(self, endpoint: str, params: Optional[Dict] = None) -> Dict[str, Any]:
         """
@@ -145,7 +145,7 @@ class VintedWrapper:
         5. If the response status code is not 200, it raises a RuntimeError with an error message.
         """
         response = self._client.get(
-            f"/api/v2{endpoint}",
+            endpoint,
             headers=get_curl_headers(
                 self._base_url, self._user_agent, self._session_cookie
             ),


### PR DESCRIPTION
This function currently adds the prefix `/api/v2`, which makes it difficult to use the created client with the necessary cookies, headers, etc. for uses other than API requests. This change allows the client to be used for possible web scraping when we need additional information from the item, and the `details` endpoint is currently difficult to use.